### PR TITLE
chore(setupCodeclimate): run codeclimate test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,15 @@ node_js:
 cache:
   directories:
   - node_modules
+addons:
+  code_climate
+before_script:
+  - export CC_TEST_REPORTER_ID=92b937d7451fb73bce6c85e2911f11d963c04ca448af582b59d4595e18398653
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
   - npm run travis
+  - npm run coverage
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/andela/ah-aquaman-frontend.svg?branch=develop)](https://travis-ci.com/andela/ah-aquaman-frontend)
+[![Build Status](https://travis-ci.com/andela/ah-aquaman-frontend.svg?branch=develop)](https://travis-ci.com/andela/ah-aquaman-frontend) [![Maintainability](https://api.codeclimate.com/v1/badges/727c9e81bf53c1fe6e78/maintainability)](https://codeclimate.com/github/andela/ah-aquaman-frontend/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/727c9e81bf53c1fe6e78/test_coverage)](https://codeclimate.com/github/andela/ah-aquaman-frontend/test_coverage)
 
 # Authors Haven.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "build": "webpack --mode production",
         "lint": "eslint . --ignore-path .gitignore",
         "fix": "eslint . --ignore-path .gitignore --fix",
-        "travis": "CI=true react-scripts test --env=jsdom -u --colors"
+        "travis": "CI=true react-scripts test --env=jsdom -u  --colors",
+        "coverage":"react-scripts test --coverage --env=jsdom -u --colors"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
**What does this PR do**
This PR runs `codeclimate` test coverage after passing the tests from `travis`.

**Description of tasks to be completed**
- Ensure that `ah-aquaman-frontend` is integrated with `codeclimate` and `travis ci`
- Ensure the `codeclimate maintainability` badge is available
- Ensure that the `test coverage` badge is available

**How can this be tested??**
- Follow up on https://codeclimate.com/github/andela/ah-aquaman-frontend to view details

**Any background context you want to provide**
- The test coverage badge reads unknown because its set to build from develop. The coverage will reflect after the changes to the Travis build are added.

However on the current branch

<img width="1075" alt="Screenshot 2019-04-03 at 19 53 46" src="https://user-images.githubusercontent.com/20795487/55497569-4e230f80-564a-11e9-9d13-816886267c96.png">
<img width="1125" alt="Screenshot 2019-04-03 at 19 45 08" src="https://user-images.githubusercontent.com/20795487/55497281-b6252600-5649-11e9-83de-98583a4f0323.png">


on Develop

<img width="1132" alt="Screenshot 2019-04-03 at 19 45 44" src="https://user-images.githubusercontent.com/20795487/55497305-c2a97e80-5649-11e9-8bfe-38d414d5d2ba.png">


**What are the relevant pivotal tracker stories**

- [#164069177](https://www.pivotaltracker.com/story/show/164069177)